### PR TITLE
Switch to using date.today in the forms so it updates properly

### DIFF
--- a/neoexchange/core/forms.py
+++ b/neoexchange/core/forms.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, date, timedelta
 from django import forms
 from django.db.models import Q
 from .models import Body, Proposal
@@ -18,7 +18,7 @@ class EphemQuery(forms.Form):
 
     target = forms.CharField(label="Enter target name...", max_length=10, required=True, widget=forms.TextInput(attrs={'size':'10'}), error_messages={'required': _(u'Target name is required')})
     site_code = forms.ChoiceField(required=True, choices=SITES)
-    utc_date = forms.DateField(input_formats=['%Y-%m-%d',], initial=datetime.utcnow().date(), required=True, widget=forms.TextInput(attrs={'size':'10'}), error_messages={'required': _(u'UTC date is required')})
+    utc_date = forms.DateField(input_formats=['%Y-%m-%d',], initial=date.today, required=True, widget=forms.TextInput(attrs={'size':'10'}), error_messages={'required': _(u'UTC date is required')})
     alt_limit = forms.FloatField(initial=30.0, required=True, widget=forms.TextInput(attrs={'size':'4'}))
 
     def clean_target(self):
@@ -34,7 +34,7 @@ class EphemQuery(forms.Form):
 class ScheduleForm(forms.Form):
     proposal_code = forms.ChoiceField(required=True)
     site_code = forms.ChoiceField(required=True, choices=SITES)
-    utc_date = forms.DateField(input_formats=['%Y-%m-%d',], initial=datetime.utcnow().date(), required=True, widget=forms.TextInput(attrs={'size':'10'}), error_messages={'required': _(u'UTC date is required')})
+    utc_date = forms.DateField(input_formats=['%Y-%m-%d',], initial=date.today, required=True, widget=forms.TextInput(attrs={'size':'10'}), error_messages={'required': _(u'UTC date is required')})
     # body_id = forms.IntegerField(widget=forms.HiddenInput())
     # ok_to_schedule = forms.BooleanField(initial=False, required=False, widget=forms.HiddenInput())
 


### PR DESCRIPTION
So I found something else that was different in the container and not on master... 
Currently the forms use datetime.utcnow().date() which just gets set once at server startup and then never changes it. This switches to using a callable that is evaluated every time; a better one that could handle the day wraps at e.g. CPT and Do The Right Thing(Tm) can come later.
