### PR TITLE
Rotate proposal ids in block summary plot for better visibility

### DIFF
--- a/neoexchange/core/templates/core/block_time_summary.html
+++ b/neoexchange/core/templates/core/block_time_summary.html
@@ -28,12 +28,12 @@ var data = {{summary|safe}};
 
         var margin = {
                                 top: 20,
-                                right: 20,
-                                bottom: 40,
+                                right: 30,
+                                bottom: 60,
                                 left: 60
                         },
                                 width = 900 - margin.left - margin.right,
-                                height = 315 - margin.top - margin.bottom,
+                                height = 345 - margin.top - margin.bottom,
                                 that = this;
 
 
@@ -69,7 +69,7 @@ var data = {{summary|safe}};
       y.domain([0, d3.max(data, function(d) { return d.total; })]);
                         x.domain(data.map(function (d) {return d.proposal;}));
 
-                        svg.append("g").attr("class", "x axis").attr("transform", "translate(0," + height + ")").call(xAxis);
+                        svg.append("g").attr("class", "x axis").attr("transform", "translate(0," + height + ")").call(xAxis).selectAll("text").style("text-anchor", "start").attr("dx", "-.8em").attr("transform", "rotate(25)" );
 
                         svg.append("g").attr("class", "y axis").call(yAxis);
 


### PR DESCRIPTION
Hey Edward, with the new semester we now have more proposals and labels on the efficiency plot. This small change rotates the labels for better visibility - what do you think?
