### PR TITLE
Reduce the persistent connection timeout to 60 seconds

### DIFF
--- a/neoexchange/neox/settings.py
+++ b/neoexchange/neox/settings.py
@@ -237,7 +237,7 @@ DATABASES = {
         "USER": os.environ.get('NEOX_DB_USER',''),
         "PASSWORD": os.environ.get('NEOX_DB_PASSWD',''),
         "HOST": os.environ.get('NEOX_DB_HOST',''),
-        "CONN_MAX_AGE" : 1800,
+        "CONN_MAX_AGE" : 60,
         "OPTIONS"   : {'init_command': 'SET storage_engine=INNODB'},
 
     }


### PR DESCRIPTION
The LCO MySQL database automatically times out idle connections after
300 seconds (5 minutes). NEO Exchange has configured persistent
connections to last 1800 seconds (30 minutes). This situation creates
many unnecessary warning messages in the database server logs.

Fix NEO Exchange by reducing the persistent connection timeout to 60
seconds.