### PR TITLE
Fix issue 202-- collapse when scheduling bad date

### DIFF
--- a/neoexchange/core/views.py
+++ b/neoexchange/core/views.py
@@ -376,10 +376,11 @@ class ScheduleParameters(LoginRequiredMixin, LookUpBodyMixin, FormView):
 
     def post(self, request, *args, **kwargs):
         form = self.get_form()
+        cadence_form = ScheduleCadenceForm()
         if form.is_valid():
             return self.form_valid(form, request)
         else:
-            return self.render_to_response(self.get_context_data(form=form, body=self.body))
+            return self.render_to_response(self.get_context_data(form=form, cad_form=cadence_form, body=self.body))
 
     def get_context_data(self, **kwargs):
         """

--- a/neoexchange/neox/settings.py
+++ b/neoexchange/neox/settings.py
@@ -295,7 +295,6 @@ if 'test' in sys.argv:
         'NAME': 'test_db', # Add the name of your SQLite3 database file here.
         },
     }
-    OPBEAT['APP_ID'] = None
 
 
 


### PR DESCRIPTION
There are some other things here that can be improved if desired:
For instance invalid dates on the cadence form will not be caught until you make it all the way to the confirmation page. This means you have to start over to fix them.

However this would require adding more form validation and improving what is passed back to the get_context_data when the form is invalid.

At the moment, we cannot handle an invalid cadence form, such as a bad date (non-existent month crashes the site), or an end date before the start date (this is a fun one. It switches to single mode, loses the cadence form entirely, looses the date box on the single form, and hitting submit will crash the site since the date doesn't exist)