### PR TITLE
add LCO spectra to list of available spectra on Body detail page

### DIFF
--- a/neoexchange/core/templates/core/body_detail.html
+++ b/neoexchange/core/templates/core/body_detail.html
@@ -312,6 +312,13 @@
 									        </tr>
 								        {% endif %}
 								    {% endfor %}
+                                    {% for sb in blocks %}
+                                        {% if sb.obstype == 1 %}
+                                            <tr>
+										        <td class="kv-key"> LCO Spectrum</td>
+                                                <td class="kv-value"><a href="{% url 'blockspec' sb.pk 1 %}">{{sb.when_observed|date:"Y-m-d"}} ({{sb.site|upper}}) </a></td>
+                                        {% endif %}
+                                    {% endfor %}
                                     {% for t in taxonomies %}
 									<tr><td ><table align="left"  style="margin: 0px"><tr>
 										<td class="kv-key" >


### PR DESCRIPTION
addresses issue #344 

Very simple solution to display our spectra.
Does not add our spectra to the `PreviousSpectra` Model.
This can be done, but I'm not sure if we want or need to. "Previous spectra" might be better if it remained "external spectra".