### PR TITLE
Fix Arecibo fetch page in case of more tables

### DIFF
--- a/neoexchange/astrometrics/tests/test_arecibo_page.html
+++ b/neoexchange/astrometrics/tests/test_arecibo_page.html
@@ -95,7 +95,35 @@ Congressional mandate of detecting and characterizing 90% of NEAs down to 140 m 
 and 
 <a href="https://twitter.com/NAICobservatory" class="twitter-follow-button" data-show-count="false">Follow @NAICobservatory</a> ! <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 </p></i>
+<table>
+<tr><td>
+<a href="images/2020BX12.feb11.gif"><img src="images/2020BX12.feb11.gif" align="center" height="400"></a>
+</td>
+</tr></table>
+<p><i>Series of range-Doppler radar images of 2020 BX12 observed February 4, 2020. </i> </p>
 
+   
+
+<br>
+
+<p> <u> <b>  Discovery Announcement of Binary System 2020 BX12   </b> </u> </p>    
+<p> Arecibo, Puerto Rico - February 10th, 2020 </p>
+<p> Radar images obtained by the Arecibo Observatory on the 4th and 5th of February revealed that near-Earth asteroid 2020 BX12 is a binary asteroid. The detection of a satellite was made during the first planetary radar observations conducted at the observatory following a month-long shutdown of telescope operations caused by a series of earthquakes striking the southern part of the island of Puerto Rico. The primary asteroid was discovered on the 27th of January by the ATLAS survey on Mauna Loa in Hawaii and fits the definition of a potentially hazardous asteroid (PHA) due to its size and minimum orbit intersection distance (MOID) of 302,000 km (188,000 miles) from the Earth. While this means it could conceivably come closer to the Earth than the Moon, 2020 BX12 poses no danger at this time and is currently receding from Earth. </p>
+
+<br>
+     
+<p>The Arecibo delay-Doppler radar images (2380 MHz, 12.6 cm) showing the asteroid and its satellite have a resolution of 7.5 meters/pixel in the vertical dimension and 0.075 Hz/pixel in the horizontal dimension (~5 mm/s). Preliminary analysis suggests that the primary asteroid is a round object at least 165 meters in diameter rotating approximately once every 2.8 hours or less. The satellite has a diameter of approximately 70 meters and rotates once every 49 hours or less. The distance between the two bodies is at least 360 m, as observed on February 5th. The movement of the satellite between the two observations, which were made ~23 hours apart, suggests a mutual orbital period of 45-50 hours and would be consistent with a tidally locked satellite. Due to projection effects, uncertainties remain on the rotation periods, and a shorter mutual orbital period of 15-16 hours has not yet been ruled out. </p>
+
+<br>
+
+<table>
+<tr><td>
+<a href="images/2020BX12.Feb2020.png"><img src="images/2020BX12.Feb2020.png" align="center" height="350"></a>
+</td>
+</tr></table>
+<p> <i>Range-Doppler radar images of binary near-Earth asteroid 2020 BX12 with range resolution of 7.5 m/pixel (vertical axis) and Doppler frequency resolution of 0.075 Hz/pixel (horizontal axis). </i> </p>
+
+<br>
 </div><br>
 <HR size="2" width="100%"><a name="2016"></a>
 <br>


### PR DESCRIPTION
Addresses issue #417  
Arecibo radar page added tables for formatting several images. This triggered the "Too many Tables" warning.

However, because we carefully parse the table results, extra tables do not confuse our ability to extract targets.