### PR TITLE
Add test and trap bad status values from sla_planel()

### DIFF
--- a/neoexchange/astrometrics/ephem_subs.py
+++ b/neoexchange/astrometrics/ephem_subs.py
@@ -276,6 +276,16 @@ def compute_ephem(d, orbelems, sitecode, dbg=False, perturb=True, display=False)
 
         logger.debug("Sun->Asteroid [x,y,z]=%s %s" % (pv[0:3], status))
         logger.debug("Sun->Asteroid [xdot,ydot,zdot]=%s %s" % (pv[3:6], status))
+        if status != 0:
+            err_mapping = { -1 : 'illegal JFORM',
+                            -2 : 'illegal E',
+                            -3 : 'illegal AORQ',
+                            -4 : 'illegal DM',
+                            -5 : 'numerical error'
+                          }
+            msg = "Position (sla_planel) error={} {}".format(status, err_mapping.get(status, 'Unknown error'))
+            logger.error(msg)
+            return {}
 
         for i, e_pos in enumerate(e_pos_hel):
             pos[i] = pv[i] - e_pos

--- a/neoexchange/astrometrics/tests/test_ephem_subs.py
+++ b/neoexchange/astrometrics/tests/test_ephem_subs.py
@@ -598,6 +598,49 @@ class TestComputeEphemerides(TestCase):
 
         self.assertEqual({}, emp_line)
 
+    def test_numerical_error(self):
+        orbelems = {
+                     'provisional_name': 'P10Ee5V',
+                     'provisional_packed': '',
+                     'name': 'C/2017 U1',
+                     'origin': 'M',
+                     'source_type': 'C',
+                     'source_subtype_1': 'H',
+                     'source_subtype_2': 'DN',
+                     'elements_type': 'MPC_COMET',
+                     'active': False,
+                     'fast_moving': False,
+                     'urgency': None,
+                     'epochofel': datetime(2017, 10, 20, 0, 0),
+                     'orbit_rms': 99.0,
+                     'orbinc': 122.48309,
+                     'longascnode': 24.60837,
+                     'argofperih': 241.31094,
+                     'eccentricity': 1.1938645,
+                     'meandist': None,
+                     'meananom': 0.0,
+                     'perihdist': 0.25316879,
+                     'epochofperih': datetime(2017, 9, 9, 10, 45, 27),
+                     'abs_mag': 22.2,
+                     'slope': 4.0,
+                     'score': 5,
+                     'discovery_date': datetime(2017, 10, 19, 7, 12),
+                     'num_obs': 57,
+                     'arc_length': 13.0,
+                     'not_seen': 0.908,
+                     'updated': True,
+                     'ingest': datetime(2017, 10, 19, 14, 20, 8),
+                     'update_time': datetime(2017, 10, 27, 17, 5, 51)}
+
+        start = datetime(2020, 11, 2, 9, 30)
+        site_code = 'W85'
+
+        try:
+            emp_line = compute_ephem(start, orbelems, site_code, perturb=False)
+            self.assertEqual({}, emp_line)
+        except ValueError:
+            self.fail("compute_ephem raised ValueError unexpectedly")
+
 
 class TestDarkAndObjectUp(TestCase):
 


### PR DESCRIPTION
@jchate6 this adds a bail out from the position calculating part of `compute_ephem` (triggered in this case by Oumuamua for at present unknown reasons). Since this was triggered originally by the visibility wheels (see Rollbar traceback), can you check this null dictionary return won't cause additional issues in the visibility wheel plotter ?