### PR TITLE
Stop trying to open MANOS Jpegs as text files

### DIFF
--- a/neoexchange/core/templates/core/body_detail.html
+++ b/neoexchange/core/templates/core/body_detail.html
@@ -296,7 +296,7 @@
 							</table>
 							<h5 class="section-title">Spectroscopy Details
                                 {% if spectra %}
-                                <a href="{% url 'plotspec' body.pk %}" style="font-size: small;">(Plots)</a>
+                                    <a href="{% url 'plotspec' body.pk %}" style="font-size: small;">(Plots)</a>
                                 {% endif %}
                             </h5>
 							<table class="keyvalue-table" id="id_spectralinfo">

--- a/neoexchange/core/views.py
+++ b/neoexchange/core/views.py
@@ -3688,7 +3688,7 @@ def plot_all_spec(source):
         body = source
         p_spec = PreviousSpectra.objects.filter(body=body)
         for spec in p_spec:
-            if spec.spec_ir:
+            if spec.spec_ir and '.txt' in spec.spec_ir:
                 wav, flux, err = pull_data_from_text(spec.spec_ir)
                 label = "{} -- {}, {}(IR)".format(body.current_name(), spec.spec_date, spec.spec_source)
                 new_spec = {'label': label,
@@ -3697,7 +3697,7 @@ def plot_all_spec(source):
                      'err': err,
                      'filename': spec.spec_ir}
                 data_spec.append(new_spec)
-            if spec.spec_vis:
+            if spec.spec_vis and '.txt' in spec.spec_vis:
                 wav, flux, err = pull_data_from_text(spec.spec_vis)
                 label = "{} -- {}, {}(Vis)".format(body.current_name(), spec.spec_date, spec.spec_ref)
                 new_spec = {'label': label,


### PR DESCRIPTION
This is a basic fix. We could just remove the link, but that requires more logic in the html which I'm not stoked about.

Closes #514 