### PR TITLE
Add observed location to SuperBlock timeline

### DIFF
--- a/neoexchange/core/models/blocks.py
+++ b/neoexchange/core/models/blocks.py
@@ -25,6 +25,7 @@ from astrometrics.ephem_subs import compute_ephem, comp_sep
 from core.archive_subs import check_for_archive_images
 
 from core.models.body import Body
+from core.models.frame import Frame
 from core.models.proposal import Proposal
 
 TELESCOPE_CHOICES = (
@@ -248,6 +249,15 @@ class Block(models.Model):
 
     def num_candidates(self):
         return Candidate.objects.filter(block=self.id).count()
+
+    def where_observed(self):
+        where_observed=''
+        if self.num_observed is not None:
+            frames = Frame.objects.filter(block=self.id, frametype=Frame.BANZAI_RED_FRAMETYPE)
+            if frames.count() > 0:
+                where_observed_qs = frames.values_list('sitecode', flat=True).distinct()
+                where_observed = ",".join(where_observed_qs)
+        return where_observed
 
     class Meta:
         verbose_name = _('Observation Block')

--- a/neoexchange/core/models/blocks.py
+++ b/neoexchange/core/models/blocks.py
@@ -255,8 +255,9 @@ class Block(models.Model):
         if self.num_observed is not None:
             frames = Frame.objects.filter(block=self.id, frametype=Frame.BANZAI_RED_FRAMETYPE)
             if frames.count() > 0:
-                where_observed_qs = frames.values_list('sitecode', flat=True).distinct()
-                where_observed = ",".join(where_observed_qs)
+                # Code for producing full site strings + site codes e.g. 'W85'
+                where_observed_qs = frames.distinct('sitecode')
+                where_observed = ",".join([site.return_site_string() + " (" + site.sitecode + ")" for site in where_observed_qs])
         return where_observed
 
     class Meta:

--- a/neoexchange/core/models/frame.py
+++ b/neoexchange/core/models/frame.py
@@ -21,8 +21,6 @@ except ImportError:
     from pickle import loads, dumps
 from base64 import b64decode, b64encode
 
-from core.models.blocks import Block
-
 class WCSField(models.Field):
 
     description = "Store astropy.wcs objects"
@@ -102,7 +100,7 @@ class Frame(models.Model):
     filename    = models.CharField('FITS filename', max_length=50, blank=True, null=True, db_index=True)
     exptime     = models.FloatField('Exposure time in seconds', null=True, blank=True)
     midpoint    = models.DateTimeField('UTC date/time of frame midpoint', null=False, blank=False, db_index=True)
-    block       = models.ForeignKey(Block, null=True, blank=True, on_delete=models.CASCADE)
+    block       = models.ForeignKey("core.Block", null=True, blank=True, on_delete=models.CASCADE)
     quality     = models.CharField('Frame Quality flags', help_text='Comma separated list of frame/condition flags', max_length=40, blank=True, default=' ')
     zeropoint   = models.FloatField('Frame zeropoint (mag.)', null=True, blank=True)
     zeropoint_err = models.FloatField('Error on Frame zeropoint (mag.)', null=True, blank=True)

--- a/neoexchange/core/static/core/js/timeline.js
+++ b/neoexchange/core/static/core/js/timeline.js
@@ -57,6 +57,7 @@ function mainContent(i, data){
   html += '<div class="maindate">Observed: '+data['num']+ '</div>';
   html += '<div class="maindate">Type: '+data['type']+ '</div>';
   html += '<div class="maindate">Duration: '+data['duration']/60.+ ' mins</div>';
+  html += '<div class="maindate">Location: '+data['location']+'</div>';
   html += '</span>';
   return html
 }

--- a/neoexchange/core/views.py
+++ b/neoexchange/core/views.py
@@ -304,7 +304,8 @@ class SuperBlockTimeline(DetailView):
                 'date' : date,
                 'num'  : blk.num_observed if blk.num_observed else 0,
                 'type' : blk.get_obstype_display(),
-                'duration' : (blk.block_end - blk.block_start).seconds
+                'duration' : (blk.block_end - blk.block_start).seconds,
+                'location' : blk.where_observed()
                 }
             blks.append(data)
         context['blocks'] = json.dumps(blks)


### PR DESCRIPTION
@zemogle I made a small enhancement to the SuperBlock observation timeline - see what you think. (I originally made it for seeing where the (456537) cadence (https://neoexchange.lco.global/block/21280/timeline/) got observed)