### PR TITLE
Address Multi-filter gif movies (Issue 534)

### DIFF
--- a/neoexchange/core/management/commands/lightcurve_extraction.py
+++ b/neoexchange/core/management/commands/lightcurve_extraction.py
@@ -378,8 +378,8 @@ class Command(BaseCommand):
 
                 obs_site = block.site
                 # Get all Useful frames from each block
-                frames_red = Frame.objects.filter(block=block.id, frametype__in=[Frame.BANZAI_RED_FRAMETYPE]).order_by('midpoint')
-                frames_ql = Frame.objects.filter(block=block.id, frametype__in=[Frame.BANZAI_QL_FRAMETYPE]).order_by('midpoint')
+                frames_red = Frame.objects.filter(block=block.id, frametype__in=[Frame.BANZAI_RED_FRAMETYPE]).order_by('filter', 'midpoint')
+                frames_ql = Frame.objects.filter(block=block.id, frametype__in=[Frame.BANZAI_QL_FRAMETYPE]).order_by('filter', 'midpoint')
                 if len(frames_red) >= len(frames_ql):
                     frames_all_zp = frames_red
                 else:
@@ -392,6 +392,7 @@ class Command(BaseCommand):
                 if frames_all_zp.count() != 0:
                     elements = model_to_dict(block.body)
                     filter_list = []
+
                     for frame in frames_all_zp:
                         # get predicted position and magnitude of target during time of each frame
                         emp_line = compute_ephem(frame.midpoint, elements, frame.sitecode)

--- a/neoexchange/photometrics/gf_movie.py
+++ b/neoexchange/photometrics/gf_movie.py
@@ -38,7 +38,7 @@ import logging
 from django.core.files.storage import default_storage
 
 from photometrics.external_codes import unpack_tarball
-from core.models import Frame, CatalogSources, Block
+from core.models import Block, Frame, CatalogSources
 from astrometrics.ephem_subs import horizons_ephem
 from astrometrics.time_subs import timeit
 from photometrics.catalog_subs import sanitize_object_name
@@ -147,7 +147,7 @@ def make_gif(frames, title=None, sort=True, fr=100, init_fr=1000, progress=True,
     # pull out files that exist
     good_fits_files = [f for f in fits_files if os.path.exists(f)]
     base_name_list = [os.path.basename(f) for f in good_fits_files]
-    if not base_name_list:
+    if len(good_fits_files) == 0:
         return "WARNING: COULD NOT FIND FITS FILES"
 
     fig = plt.figure()


### PR DESCRIPTION
closes #534 

Addresses this issue by stacking all the frames from each filter together and playing them sequentially in a single gif.
Updates header information with instrument and filter from each frame.

Also removes the earlier behavior of adding an "empty" gif frame for any missing fits files that it cannot find. This would leave brief pauses in the movie and be included in the total frames number at the top of the gif. 