### PR TITLE
Issue 570

### DIFF
--- a/neoexchange/astrometrics/sources_subs.py
+++ b/neoexchange/astrometrics/sources_subs.py
@@ -117,7 +117,10 @@ def fetchpage_and_make_soup(url, fakeagent=False, dbg=False, parser="html.parser
         else:
             logger.warning("Page retrieval failed with HTTP Error: %s" % (e.reason,))
         return None
-    except (BrokenPipeError, ConnectionAbortedError, ConnectionRefusedError, ConnectionResetError, timeout) as sock_e:
+    except (BrokenPipeError, ConnectionAbortedError, ConnectionRefusedError, ConnectionResetError) as sock_e:
+        logger.warning("Page retrieval failed with socket Error %d: %s" % (sock_e.errno, sock_e.strerror))
+        return None
+    except timeout as sock_e:
         logger.warning("Page retrieval failed with socket Error %d: %s" % (sock_e.errno, sock_e.strerror))
         return None
 

--- a/neoexchange/astrometrics/tests/test_sources_subs.py
+++ b/neoexchange/astrometrics/tests/test_sources_subs.py
@@ -15,7 +15,8 @@ GNU General Public License for more details.
 
 import os
 from mock import patch, MagicMock
-from socket import error
+from socket import error, timeout
+from errno import ETIMEDOUT
 from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 from unittest import skipIf
@@ -4016,6 +4017,26 @@ class TestSFUFetch(TestCase):
 
         self.assertEqual(expected_result[0], sfu_result[0])
         self.assertEqual(expected_result[1], sfu_result[1])
+
+    # Uncomment and remove catch of `timeout` in fetchpage_and_make_soup() to
+    # test the mock is working.
+
+    # @patch('astrometrics.sources_subs.urllib.request.OpenerDirector.open')
+    # def test_fetch_socket_timeout_assert_raises(self, mock_open):
+        # mock_open.side_effect = timeout(ETIMEDOUT, '(fake) timed out')
+
+        # with self.assertRaises(timeout) as sock_e:
+            # sfu_result = fetchpage_and_make_soup('http://www.spaceweather.gc.ca/solarflux/sx-4-en.php')
+        # self.assertEqual(sock_e.exception.errno, ETIMEDOUT)
+        # self.assertEqual(sock_e.exception.strerror, '(fake) timed out')
+
+    @patch('astrometrics.sources_subs.urllib.request.OpenerDirector.open')
+    def test_fetch_socket_timeout_handled(self, mock_open):
+        mock_open.side_effect = timeout(ETIMEDOUT, '(fake) timed out')
+
+        sfu_result = fetch_sfu()
+
+        self.assertEqual((None, None), sfu_result)
 
 
 class TestConfigureDefaults(TestCase):


### PR DESCRIPTION
This *should* handle the socket timeout issues we intermittently get from the SFU fetcher. Fixes Issues #570 and Rollbar issues #208, #210, #228 and #229