### PR TITLE
Feature/dithering

### DIFF
--- a/neoexchange/astrometrics/tests/test_sources_subs.py
+++ b/neoexchange/astrometrics/tests/test_sources_subs.py
@@ -6019,3 +6019,24 @@ class TestFetchJPLPhysParams(TestCase):
         self.assertLessEqual(len(body.source_subtype_1), 2)
         self.assertEqual(body.source_subtype_1, 'LP')
 
+
+class TestBoxSpiral(TestCase):
+
+    def test_run_generator(self):
+        """Test Box Spiral generator"""
+
+        b = box_spiral_generator(1, 3)
+        self.assertEqual((0, 0), next(b))
+        self.assertEqual((1, 0), next(b))
+        self.assertEqual((1, 1), next(b))
+        self.assertEqual((0, 1), next(b))
+        self.assertEqual((-1, 1), next(b))
+        self.assertEqual((-1, 0), next(b))
+        for k, b_next in enumerate(b):
+            if k == 23:
+                self.assertEqual((3, 2), b_next)
+            if k == 24:
+                self.assertEqual((0, 0), b_next)
+            if k == 25:
+                self.assertEqual((1, 0), b_next)
+                break

--- a/neoexchange/astrometrics/tests/test_sources_subs.py
+++ b/neoexchange/astrometrics/tests/test_sources_subs.py
@@ -5146,6 +5146,32 @@ class TestMakeconfigurations(TestCase):
         self.assertEqual(inst_configs[30]['extra_params'], {'offset_ra': 60.0, 'offset_dec': 60.0})
         self.assertEqual(inst_configs[91]['extra_params'], {'offset_ra': 20.0, 'offset_dec': 0.0})
 
+    def test_muscat_dithering(self):
+
+        expected_num_configurations = 1
+        expected_type = 'EXPOSE'
+        expected_num_inst_configurations = 10
+        expected_exp_num = 1
+        params = self.params_2m0_imaging
+        params['dither_distance'] = 10
+        params['add_dither'] = True
+        params['exp_count'] = 10
+
+        configurations = make_configs(params)
+
+        self.assertEqual(expected_num_configurations, len(configurations))
+        self.assertEqual(expected_type, configurations[0]['type'])
+
+        inst_configs = configurations[0]['instrument_configs']
+        self.assertEqual(expected_num_inst_configurations, len(inst_configs))
+        self.assertEqual(inst_configs[0]['exposure_count'], expected_exp_num)
+        self.assertEqual(inst_configs[0]['extra_params']['offset_ra'], 0.0)
+        self.assertEqual(inst_configs[0]['extra_params']['offset_dec'], 0.0)
+        self.assertEqual(inst_configs[0]['extra_params']['exposure_mode'], 'SYNCHRONOUS')
+        self.assertEqual(inst_configs[0]['extra_params']['exposure_time_g'], 60)
+        self.assertEqual(inst_configs[6]['extra_params']['offset_ra'], -10.0)
+        self.assertEqual(inst_configs[6]['extra_params']['offset_dec'], -10.0)
+
     def test_0m4_imaging(self):
 
         expected_num_configurations = 1

--- a/neoexchange/core/forms.py
+++ b/neoexchange/core/forms.py
@@ -226,6 +226,8 @@ class ScheduleBlockForm(forms.Form):
     acceptability_threshold = forms.FloatField(widget=forms.NumberInput(attrs={'style': 'width: 75px;'}), required=False)
     ag_exp_time = forms.FloatField(widget=forms.NumberInput(attrs={'style': 'width: 75px;'}), required=False)
     edit_window = forms.BooleanField(initial=False, required=False, widget=forms.CheckboxInput(attrs={'class': 'window-switch'}))
+    add_dither = forms.BooleanField(initial=False, required=False, widget=forms.CheckboxInput(attrs={'class': 'dither-switch'}))
+    dither_distance = forms.FloatField(widget=forms.NumberInput(attrs={'style': 'width: 75px;'}), required=False)
     gp_explength = forms.FloatField(required=False, widget=forms.NumberInput(attrs={'size': '5'}))
     rp_explength = forms.FloatField(required=False, widget=forms.NumberInput(attrs={'size': '5'}))
     ip_explength = forms.FloatField(required=False, widget=forms.NumberInput(attrs={'size': '5'}))

--- a/neoexchange/core/forms.py
+++ b/neoexchange/core/forms.py
@@ -234,6 +234,14 @@ class ScheduleBlockForm(forms.Form):
     zp_explength = forms.FloatField(required=False, widget=forms.NumberInput(attrs={'size': '5'}))
     muscat_sync = forms.BooleanField(initial=False, required=False)
 
+    def clean_dither_distance(self):
+        """Limit dither distance to values between 0 and 60 arcsec."""
+        if not self.cleaned_data['dither_distance'] or self.cleaned_data['dither_distance'] < 0:
+            return 10
+        if self.cleaned_data['dither_distance'] > 60:
+            return 60
+        return self.cleaned_data['dither_distance']
+
     def clean_exp_length(self):
         if not self.cleaned_data['exp_length'] or self.cleaned_data['exp_length'] < 0.1:
             return 0.1

--- a/neoexchange/core/templates/core/schedule_confirm.html
+++ b/neoexchange/core/templates/core/schedule_confirm.html
@@ -23,10 +23,10 @@
     if(ds){
         if(ds.checked){
             $('#no_dither').hide();
-            $('#dither_dist').show();
+            $('#dither_dist_row').show();
         } else {
-            $('#dither_dist').hide();
-            $('#no_window').show();
+            $('#dither_dist_row').hide();
+            $('#no_dither').show();
         }
     }
 
@@ -528,7 +528,7 @@
               </tr>
               <tr id="no_dither" class="mode-dither">
               </tr>
-              <tr id="dither_dist" class="mode-dither">
+              <tr id="dither_dist_row" class="mode-dither">
                   <td ><table align="left"  style="margin: 0px"><tr><td class="kv-key">
                         <div class="tooltip">Dither Separation (")
                         <span class="tooltiptext" style="left:75%">

--- a/neoexchange/core/templates/core/schedule_confirm.html
+++ b/neoexchange/core/templates/core/schedule_confirm.html
@@ -529,7 +529,11 @@
               <tr id="no_dither" class="mode-dither">
               </tr>
               <tr id="dither_dist" class="mode-dither">
-                  <td class="kv-key">Dither Separation (")</td>
+                  <td ><table align="left"  style="margin: 0px"><tr><td class="kv-key">
+                        <div class="tooltip">Dither Separation (")
+                        <span class="tooltiptext" style="left:75%">
+                            Must be a value between 0 and 60".
+                      </span></span></div></td><td></td></tr></table></td>
                 <td class="kv-value">
                     {{ form.dither_distance }}
                 </td>

--- a/neoexchange/core/templates/core/schedule_confirm.html
+++ b/neoexchange/core/templates/core/schedule_confirm.html
@@ -19,12 +19,27 @@
         $('#data_window').show();
     }
 
+    var ds = document.getElementById("id_add_dither");
+    if(ds){
+        if(ds.checked){
+            $('#no_dither').hide();
+            $('#dither_dist').show();
+        } else {
+            $('#dither_dist').hide();
+            $('#no_window').show();
+        }
+    }
+
     $('a.mode-switch').click(function(event){
       $('.mode-container').toggle();
     });
 
     $('.window-switch').click(function(event){
       $('.mode-window').toggle();
+    });
+
+    $('.dither-switch').click(function(event){
+      $('.mode-dither').toggle();
     });
 
   });
@@ -459,6 +474,7 @@
                   <td class="kv-key">Acceptability Threshold (%)</td>
                   <td class="kv-value">{{ form.acceptability_threshold }}</td>
               </tr>
+
               {% if data.spectroscopy %}
               <tr id="id_ag_exp_time_row">
                   <td class="kv-key">GuideCam Exposure time (s)</td>
@@ -491,6 +507,23 @@
                       <td class="kv-value">{{ form.calibsource_list }}</td>
                   </tr>
               {% endif %}
+              {% else %}
+              <tr id="id_dither_row">
+                  <td class="kv-key">Add Dithering?
+                  <td class="kv-value">
+                        <div class="compact-field">
+                            {{ form.add_dither}}<label for="id_add_dither"></label>
+                        </div>
+                  </td>
+              </tr>
+              <tr id="no_dither" class="mode-dither">
+              </tr>
+              <tr id="dither_dist" class="mode-dither">
+                  <td class="kv-key">Dither Separation (")</td>
+                <td class="kv-value">
+                    {{ form.dither_distance }}
+                </td>
+              </tr>
               {% endif %}
           </table>
           </div>

--- a/neoexchange/core/templates/core/schedule_confirm.html
+++ b/neoexchange/core/templates/core/schedule_confirm.html
@@ -509,7 +509,17 @@
               {% endif %}
               {% else %}
               <tr id="id_dither_row">
-                  <td class="kv-key">Add Dithering?
+                  <td ><table align="left"  style="margin: 0px"><tr><td class="kv-key">
+                        <div class="tooltip">Add Dithering?
+                        <span class="tooltiptext" style="left:75%">
+                            <b>Add Dithering</b> to offset each image by the given distance in a box-spiral pattern starting at the target. <br> <br>
+                            The pattern will reset if the center ever gets further than 120" from the target.
+                             <font size="+1"><pre>&#9635; &larr; &#9635; &larr; &#9635;   &#9635;</pre>
+                                             <pre>&darr;        &uarr;   &uarr;</pre>
+                                             <pre>&#9635;   &#9673; &rarr; &#9635;   &#9635;</pre>
+                                             <pre>&darr;            &uarr;</pre>
+                                             <pre>&#9635; &rarr; &#9635; &rarr; &#9635; &rarr; &#9635;</pre> </font>
+                        </span></span></div></td><td></td></tr></table></td>
                   <td class="kv-value">
                         <div class="compact-field">
                             {{ form.add_dither}}<label for="id_add_dither"></label>

--- a/neoexchange/core/tests/test_views.py
+++ b/neoexchange/core/tests/test_views.py
@@ -1280,7 +1280,9 @@ class TestScheduleCheck(TestCase):
                             'max_airmass': 1.74,
                             'max_alt_airmass': 1.0861815238132588,
                             'min_lunar_dist': 30,
-                            'acceptability_threshold': 90
+                            'acceptability_threshold': 90,
+                            'dither_distance': 10,
+                            'add_dither': False,
                         }
 
     def make_visible_obj(self, test_date):
@@ -1804,11 +1806,11 @@ class TestScheduleCheck(TestCase):
     def test_mp_bad_too(self):
         MockDateTime.change_datetime(2016, 4, 6, 2, 0, 0)
 
-        data = { 'site_code' : 'Q63',
-                 'utc_date' : datetime(2016, 4, 6).date(),
-                 'proposal_code' : self.neo_proposal.code,
-                 'too_mode' : True
-               }
+        data = {'site_code': 'Q63',
+                'utc_date': datetime(2016, 4, 6).date(),
+                'proposal_code': self.neo_proposal.code,
+                'too_mode': True
+                }
 
         expected_resp1 = self.expected_resp
         expected_resp1['site_code'] = data['site_code']
@@ -1891,7 +1893,9 @@ class TestScheduleCheck(TestCase):
                         'max_airmass': 2.0,
                         'max_alt_airmass': 1.0861815238132588,
                         'min_lunar_dist': 30,
-                        'acceptability_threshold': 90
+                        'acceptability_threshold': 90,
+                        'dither_distance': 10,
+                        'add_dither': False,
                         }
 
         resp = schedule_check(data, self.body_mp)
@@ -1970,7 +1974,9 @@ class TestScheduleCheck(TestCase):
                         'max_airmass': 2.0,
                         'max_alt_airmass': 1.0861815238132588,
                         'min_lunar_dist': 30,
-                        'acceptability_threshold': 90
+                        'acceptability_threshold': 90,
+                        'dither_distance': 10,
+                        'add_dither': False,
                         }
 
         resp = schedule_check(data, self.body_mp)

--- a/neoexchange/core/views.py
+++ b/neoexchange/core/views.py
@@ -1476,11 +1476,23 @@ def schedule_check(data, body, ok_to_schedule=True):
         suffix += "_spectra"
     if too_mode is True:
         suffix += '_ToO'
+    # Define possible tags that can be added on confirmation page
+    possible_tags = ['_bin2x2', '_dither']
+    # Build defualt group name
     default_group_name = body.current_name() + '_' + data['site_code'].upper() + '-' + suffix
-    if not group_name or (group_name == default_group_name + '_bin2x2' and bin_mode != '2k_2x2'):
+    # Test group name for custom user additions
+    test_name = group_name
+    test_name = test_name.replace(default_group_name, '')
+    for tag in possible_tags:
+        test_name = test_name.replace(tag, '')
+    # If no name, or no user additions, remake group name
+    if not group_name or not test_name:
         group_name = default_group_name
-    if group_name == default_group_name and bin_mode == '2k_2x2':
-        group_name += '_bin2x2'
+    if group_name == default_group_name:
+        if bin_mode == '2k_2x2':
+            group_name += possible_tags[0]
+        if data.get('add_dither', False):
+            group_name += possible_tags[1]
 
     resp = {
         'target_name': body.current_name(),

--- a/neoexchange/core/views.py
+++ b/neoexchange/core/views.py
@@ -1550,7 +1550,7 @@ def schedule_check(data, body, ok_to_schedule=True):
         'calibsource_predict_exptime': sa_predicted_exptime,
         'calibsource_list_options': calib_list,
         'calibsource_list': calibsource_list_init,
-        'dither_distance': data.get('dither_distance', 10),
+        'dither_distance': data.get('dither_distance', 10),  # set default value to 10 arcsec.
         'add_dither': data.get('add_dither', False),
     }
 
@@ -1666,7 +1666,7 @@ def schedule_submit(data, body, username):
               'acceptability_threshold': data.get('acceptability_threshold', 90),
               'ag_exp_time': data.get('ag_exp_time', 10),
               'dither_distance': data.get('dither_distance', 10),
-              'add_dither': data['add_dither']
+              'add_dither': data.get('add_dither', False)
               }
     if data['period'] or data['jitter']:
         params['period'] = data['period']

--- a/neoexchange/core/views.py
+++ b/neoexchange/core/views.py
@@ -1469,7 +1469,8 @@ def schedule_check(data, body, ok_to_schedule=True):
     # Create Group ID
     group_name = validate_text(data.get('group_name', None))
 
-    suffix = datetime.strftime(utc_date, '%Y%m%d')
+    name_date = datetime.strftime(utc_date, '-%Y%m%d')
+    suffix = ''
     if period and jitter:
         suffix = "cad-%s-%s" % (datetime.strftime(rise_time, '%Y%m%d'), datetime.strftime(set_time, '%m%d'))
     elif spectroscopy:
@@ -1479,12 +1480,19 @@ def schedule_check(data, body, ok_to_schedule=True):
     # Define possible tags that can be added on confirmation page
     possible_tags = ['_bin2x2', '_dither']
     # Build defualt group name
-    default_group_name = body.current_name() + '_' + data['site_code'].upper() + '-' + suffix
+    base_group_name = body.current_name() + '_' + data['site_code'].upper()
+    default_group_name = base_group_name + name_date + suffix
     # Test group name for custom user additions
     test_name = group_name
-    test_name = test_name.replace(default_group_name, '')
+    test_name = test_name.replace(base_group_name, '')
+    test_name = test_name.replace(suffix, '')
+    test_name = test_name.replace(name_date, '')
     for tag in possible_tags:
         test_name = test_name.replace(tag, '')
+    # Check for new date
+    test_name = test_name.replace('-20', '')
+    if test_name.isdigit() and len(test_name) == 6:
+        test_name = ''
     # If no name, or no user additions, remake group name
     if not group_name or not test_name:
         group_name = default_group_name

--- a/neoexchange/core/views.py
+++ b/neoexchange/core/views.py
@@ -1650,7 +1650,8 @@ def schedule_submit(data, body, username):
               'para_angle': data.get('para_angle', False),
               'min_lunar_distance': data.get('min_lunar_dist', 30),
               'acceptability_threshold': data.get('acceptability_threshold', 90),
-              'ag_exp_time': data.get('ag_exp_time', 10)
+              'ag_exp_time': data.get('ag_exp_time', 10),
+              'dither_distance': data.get('dither_distance', 10)
               }
     if data['period'] or data['jitter']:
         params['period'] = data['period']

--- a/neoexchange/core/views.py
+++ b/neoexchange/core/views.py
@@ -1538,6 +1538,8 @@ def schedule_check(data, body, ok_to_schedule=True):
         'calibsource_predict_exptime': sa_predicted_exptime,
         'calibsource_list_options': calib_list,
         'calibsource_list': calibsource_list_init,
+        'dither_distance': data.get('dither_distance', 10),
+        'add_dither': data.get('add_dither', False),
     }
 
     if not spectroscopy and 'F65' in data['site_code']:
@@ -1651,7 +1653,8 @@ def schedule_submit(data, body, username):
               'min_lunar_distance': data.get('min_lunar_dist', 30),
               'acceptability_threshold': data.get('acceptability_threshold', 90),
               'ag_exp_time': data.get('ag_exp_time', 10),
-              'dither_distance': data.get('dither_distance', 10)
+              'dither_distance': data.get('dither_distance', 10),
+              'add_dither': data['add_dither']
               }
     if data['period'] or data['jitter']:
         params['period'] = data['period']

--- a/neoexchange/neox/tests/base.py
+++ b/neoexchange/neox/tests/base.py
@@ -285,18 +285,18 @@ class FunctionalTest(StaticLiveServerTestCase):
                     if major_version.isdigit() and int(major_version) <= 52:
                         firefox_capabilities['marionette'] = False
                 options = webdriver.firefox.options.Options()
-                options.add_argument('--headless')
+                # options.add_argument('--headless')
                 self.browser = webdriver.Firefox(capabilities=firefox_capabilities, firefox_profile=fp, options=options)
         else:
             options = webdriver.chrome.options.Options()
-            options.add_argument('--headless')
+            # options.add_argument('--headless')
             options.add_argument('--no-sandbox')
             options.add_argument('--disable-gpu')
             self.browser = webdriver.Chrome(chrome_options=options)
         self.browser.implicitly_wait(5)
 
     def tearDown(self):
-        self.browser.quit()
+        # self.browser.quit()
         with self.settings(MEDIA_ROOT=self.test_dir):
             remove = True
             debug_print = False

--- a/neoexchange/neox/tests/base.py
+++ b/neoexchange/neox/tests/base.py
@@ -285,18 +285,18 @@ class FunctionalTest(StaticLiveServerTestCase):
                     if major_version.isdigit() and int(major_version) <= 52:
                         firefox_capabilities['marionette'] = False
                 options = webdriver.firefox.options.Options()
-                # options.add_argument('--headless')
+                options.add_argument('--headless')
                 self.browser = webdriver.Firefox(capabilities=firefox_capabilities, firefox_profile=fp, options=options)
         else:
             options = webdriver.chrome.options.Options()
-            # options.add_argument('--headless')
+            options.add_argument('--headless')
             options.add_argument('--no-sandbox')
             options.add_argument('--disable-gpu')
             self.browser = webdriver.Chrome(chrome_options=options)
         self.browser.implicitly_wait(5)
 
     def tearDown(self):
-        # self.browser.quit()
+        self.browser.quit()
         with self.settings(MEDIA_ROOT=self.test_dir):
             remove = True
             debug_print = False

--- a/neoexchange/neox/tests/test_schedule_observations.py
+++ b/neoexchange/neox/tests/test_schedule_observations.py
@@ -780,8 +780,27 @@ class ScheduleObservations(FunctionalTest):
         with self.wait_for_page_load(timeout=10):
             self.browser.find_element_by_id("id_edit_button").click()
 
+        # Bart saw a dithering option just now, what's that do?
+        self.browser.find_element_by_id("advanced-switch").click()
+        self.browser.find_element_by_id('id_add_dither').click()
+        dither_box = self.browser.find_element_by_id('id_dither_distance')
+        self.assertIn('10', dither_box.get_attribute('value'))
+        dither_box.clear()
+        dither_box.send_keys('30')
+        with self.wait_for_page_load(timeout=10):
+            self.browser.find_element_by_id("id_edit_button").click()
+        self.browser.find_element_by_id("advanced-switch").click()
+        dither_box = self.browser.find_element_by_id('id_dither_distance')
+        self.assertIn('30', dither_box.get_attribute('value'))
+        group_id_box = self.browser.find_element_by_name("group_name")
+        self.assertIn('_dither', group_id_box.get_attribute('value'))
+        self.browser.find_element_by_id('id_add_dither').click()
+        with self.wait_for_page_load(timeout=10):
+            self.browser.find_element_by_id("id_edit_button").click()
+
         # Bart wants to be a little &^%$ and stress test our group ID input
         group_id_box = self.browser.find_element_by_name("group_name")
+        self.assertNotIn('_dither', group_id_box.get_attribute('value'))
         group_id_box.clear()
         bs_string = 'ຢູ່ໃກ້Γη小惑星‽'
         group_id_box.send_keys(bs_string)


### PR DESCRIPTION
Add dithering capability to Neoexchange.
Closes #565 

Current Capability:
Submits request for dithered observations with an escalating box spiral pattern.
Dither distance defaults to 10", but can be set to any value between 0" and 60".
Dither pattern repeats after it has reached a total extent of 120".

When dithering is activated, neoexchange automatically turns any observations requested into fully dithered observations, meaning there is no functionality for taking multiple frames between offsets. 

Current filter patterns are maintained, but dithered. Muscat observations will be dithered after the longest exposure, and asynchronous observations are effectively overridden.