### PR TITLE
Issue 635 add spectrophotometric standards only view

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Portal for scheduling observations of NEOs (and other Solar System objects) usin
 
 ## History
 
+### 3.14.3
+* Add ability to filter Calibration Sources to only show spectrophotometric standards.
+
 ### 3.14.1
 * Upgraded backend to Django 4.1, tweaks to the test suite to work better on other non-Linux platforms.
 

--- a/neoexchange/core/plots.py
+++ b/neoexchange/core/plots.py
@@ -269,6 +269,20 @@ def make_solar_standards_plot(request):
     return HttpResponse(buffer.getvalue(), content_type="Image/png")
 
 
+def make_spectrophotometric_standards_plot(request):
+    """creates spectrophotometric standards plot to be added to page"""
+
+    scoords = readSources('Flux')
+    ax = plt.figure().gca()
+    plotScatter(ax, scoords, 'g*')
+    plotFormat(ax, 2)
+    buffer = io.BytesIO()
+    plt.savefig(buffer, format='png')
+    plt.close()
+
+    return HttpResponse(buffer.getvalue(), content_type="Image/png")
+
+
 def spec_plot(data_spec, analog_data, reflec=False):
     """Builds the actual Bokeh Plots for various spectra
         INPUTS:

--- a/neoexchange/core/templates/core/calibsource_list.html
+++ b/neoexchange/core/templates/core/calibsource_list.html
@@ -91,6 +91,8 @@
             <div class="row">
                 {% if "solar" in request.get_full_path %}
                     <img src="{% url 'make-solar-standards-plot' %}" class="pic_center">
+                {% elif "spectrophotometric" in request.get_full_path %}
+                    <img src="{% url 'make-spectrophotometric-standards-plot' %}" class="pic_center">
                 {% else %}
                     <img src="{% url 'make-standards-plot' %}" class="pic_center">
                 {% endif %}

--- a/neoexchange/core/templates/core/calibsource_list.html
+++ b/neoexchange/core/templates/core/calibsource_list.html
@@ -1,13 +1,27 @@
 {% extends 'base.html' %}
 {% load static basic_tags %}
-{% block header %}Calibration Sources{% endblock %}
+{% block header %}
+    {% if "solar" in request.get_full_path %}
+        Solar Spectrum Calibration Sources
+    {% elif "spectrophotometric" in request.get_full_path %}
+        Spectrophotometric Calibration Sources
+    {% else %}
+        Calibration Sources
+    {% endif %}
+{% endblock %}
 
 {% block bodyclass %}page{% endblock %}
 
 
 {% block extramenu %}
     <div class="headingleft">
-        <h1>Calibration Sources</h1>
+        {% if "solar" in request.get_full_path %}
+            <h1>Solar Spectrum Calibration Sources</h1>
+        {% elif "spectrophotometric" in request.get_full_path %}
+            <h1>Spectrophotometric Calibration Sources</h1>
+        {% else %}
+            <h1>Calibration Sources</h1>
+        {% endif %}
     </div>
 {% endblock%}
 
@@ -15,7 +29,7 @@
     <div id="main" class="fill-height">
         <div class="container">
             <div class="row">
-                {% if "solar" in request.get_full_path %}
+                {% if "solar" in request.get_full_path or "spectrophotometric" in request.get_full_path %}
                     <a class="button button-primary" href="{% url 'schedule-calib-spectra' 'F65-FLOYDS' '-' %}" id="schedule-solar-ftn-obs">Schedule FTN Calib Observations</a>
                     <a class="button button-primary" href="{% url 'schedule-calib-spectra' 'E10-FLOYDS' '-' %}" id="schedule-solar-fts-obs">Schedule FTS Calib Observations</a>
                     <a class="button button-primary" href="{% url 'calibsource-view' %}" id="show-all-calibsources">Show all Calibration Sources</a>
@@ -24,6 +38,7 @@
                     <a class="button button-primary" href="{% url 'schedule-calib-spectra' 'F65-FLOYDS' '-' %}" id="schedule-calib-ftn-obs">Schedule FTN Calib Observations</a>
                     <a class="button button-primary" href="{% url 'schedule-calib-spectra' 'E10-FLOYDS' '-' %}" id="schedule-calib-fts-obs">Schedule FTS Calib Observations</a>
                     <a class="button button-primary" href="{% url 'solarstandard-view' %}" id="show-solar-standards">Show only Solar Analogs</a>
+                    <a class="button button-primary" href="{% url 'spectrophotstandard-view' %}" id="show-spectrophot-standards">Show only Spectrophotometrics</a>
                     <a class="button button-primary" href="{% url 'beststandards-view' %}" id="show-best-standards">Show best standards</a>
                 {% endif %}
             </div>

--- a/neoexchange/neox/settings.py
+++ b/neoexchange/neox/settings.py
@@ -7,7 +7,7 @@ from django.utils.crypto import get_random_string
 import rollbar
 
 
-VERSION = '3.14.1'
+VERSION = '3.14.3a'
 
 
 CURRENT_PATH = os.path.dirname(os.path.realpath(__file__))

--- a/neoexchange/neox/urls.py
+++ b/neoexchange/neox/urls.py
@@ -32,7 +32,8 @@ from core.views import BodySearchView, BodyDetailView, BlockDetailView, Schedule
     BestStandardsView, PlotSpec, BodyVisibilityView, SuperBlockTimeline, BlockCancel, \
     look_project, AddTarget, display_textfile
 from core.plots import make_visibility_plot, \
-    make_standards_plot, make_solar_standards_plot
+    make_standards_plot, make_solar_standards_plot, \
+    make_spectrophotometric_standards_plot
 
 from analyser.views import BlockFramesView, ProcessCandidates
 
@@ -45,6 +46,7 @@ urlpatterns = [
     # path('plotframe/', TemplateView.as_view(template_name='core/frame_plot.html')),
     path('make-standards-plot/', make_standards_plot, name='make-standards-plot'),
     path('make-solar-standards-plot/', make_solar_standards_plot, name='make-solar-standards-plot'),
+    path('make-spectrophotometric-standards-plot/', make_spectrophotometric_standards_plot, name='make-spectrophotometric-standards-plot'),
     path('visibility_plot/<int:pk>/<str:plot_type>/', make_visibility_plot, name='visibility-plot'),
     re_path(r'^visibility_plot/(?P<pk>\d+)/(?P<plot_type>[a-z]*)/(?P<site_code>[A-Z,0-9]{3})/', make_visibility_plot, name='visibility-plot-site'),
     path('block/summary/', BlockTimeSummary.as_view(), name='block-summary'),

--- a/neoexchange/neox/urls.py
+++ b/neoexchange/neox/urls.py
@@ -83,6 +83,7 @@ urlpatterns = [
     path('calibsources/', StaticSourceView.as_view(), name='calibsource-view'),
     path('calibsources/best/', BestStandardsView.as_view(), name='beststandards-view'),
     path('calibsources/solar/', StaticSourceView.as_view(queryset=StaticSource.objects.filter(source_type=StaticSource.SOLAR_STANDARD).order_by('ra')), name='solarstandard-view'),
+    path('calibsources/spectrophotometric/', StaticSourceView.as_view(queryset=StaticSource.objects.filter(source_type=StaticSource.FLUX_STANDARD).order_by('ra')), name='spectrophotstandard-view'),
     path('calibsources/<int:pk>/', StaticSourceDetailView.as_view(model=StaticSource), name='calibsource'),
     path('characterization/', characterization, name='characterization'),
     path('lookproject/', look_project, name='look_project'),

--- a/neoexchange/photometrics/SA_scatter.py
+++ b/neoexchange/photometrics/SA_scatter.py
@@ -92,6 +92,8 @@ def plotScatter(ax,coords,style='b.'):
 def plotFormat(ax,solar=0):
     """Formats plot, plots reference ecliptic and galactic plane
        inputs: <ax> plot axis
+       Set solar=0 to plot both solar and flux standards, 1 for just solar
+       standards and 2 for just flux standards
     """
     ax.plot(24*np.arange(0,1,.01),23.4*np.sin(np.arange(0,2*np.pi,2*np.pi/100)),'r-') #ecliptic (approx)
     ax.plot(genGalPlane().ra.hour,genGalPlane().dec,'y-') #galactic plane (exact)
@@ -103,14 +105,17 @@ def plotFormat(ax,solar=0):
     plt.yticks(np.arange(-90,90,15))
     if not solar:
         leg = ax.legend(loc='best',
-        handles=[mpatches.Patch(color='blue',label='Solar Standard'),
-        mpatches.Patch(color='green',label='Flux Standard')])
+            handles=[mpatches.Patch(color='blue',label='Solar Standard'),
+            mpatches.Patch(color='green',label='Flux Standard')])
+    elif solar == 2:
+         leg = ax.legend(loc='best',
+            handles=[mpatches.Patch(color='green',label='Flux Standard'),])
     else:
         leg = ax.legend(loc='best',
-        handles=[mpatches.Patch(color='blue',label='Solar Standard')])
+            handles=[mpatches.Patch(color='blue',label='Solar Standard')])
     leg.get_frame().set_alpha(.5)
-    plt.text(24,68,'Galactic Plane',fontsize=7,rotation=-25,color='#938200')
-    plt.text(9.5,14,'Ecliptic',fontsize=7,rotation=25,color='r')
+    plt.text(24,55,'Galactic Plane',fontsize=7,rotation=-25,color='#938200')
+    plt.text(9.5,16,'Ecliptic',fontsize=7,rotation=25,color='r')
     plt.title("Stellar Standards Distribution")
 
     plt.grid(True)


### PR DESCRIPTION
Hey @emannenicholas can you check out and `http://neoexchange-dev.lco.gtn/calibsources/` and see if its new 'Show Only Spectrophotometrics' (man, that word is so long..) works for you also ? If so I will merge and deploy to production on Monday